### PR TITLE
✨ Cascade R-CNN 모델 추가

### DIFF
--- a/mmdetection/config/cascade_rcnn_config.py
+++ b/mmdetection/config/cascade_rcnn_config.py
@@ -1,0 +1,46 @@
+# cascade_rcnn_config.py
+import os
+
+from .base_config import BaseConfig
+from mmcv import Config
+
+
+class cascade_rcnn_config(BaseConfig):
+    def __init__(self):
+        super().__init__()
+        self.config_dir = '/data/ephemeral/home/mmdetection/configs/cascade_rcnn/cascade_rcnn_x101_64x4d_fpn_20e_coco.py'
+        self.model_name = os.path.basename(self.config_dir).split('.')[0]
+        try:
+            self.cfg = Config.fromfile(self.config_dir)
+        except Exception as e:
+            raise RuntimeError(f"설정 파일을 불러오는 데 실패했습니다: {str(e)}")
+
+    def build_config(self):
+        self.cfg = self.setup_config(self.cfg)
+        # dataset config 수정
+        self.cfg.data.train.classes = self.classes
+        self.cfg.data.train.img_prefix = self.data_dir
+        self.cfg.data.train.ann_file = self.data_dir + 'train2.json' # train json 정보
+        self.cfg.data.train.pipeline[2]['img_scale'] = (512,512) # Resize
+        
+        
+        self.cfg.data.val.classes = self.classes
+        self.cfg.data.val.img_prefix = self.data_dir
+        self.cfg.data.val.ann_file = self.data_dir + 'val2.json' # val json 정보
+        self.cfg.data.val.pipeline[1]['img_scale'] = (512,512) # Resize
+
+        self.cfg.data.test.classes = self.classes
+        self.cfg.data.test.img_prefix = self.data_dir
+        self.cfg.data.test.ann_file = self.data_dir + 'test.json' # test json 정보
+        self.cfg.data.test.pipeline[1]['img_scale'] = (512,512) # Resize
+
+        # print(self.cfg.data)
+        # exit()
+
+        self.cfg.data.samples_per_gpu = 16
+        for bbox_head in self.cfg.model.roi_head.bbox_head:
+            bbox_head['num_classes'] = self.num_classes
+        # 학습 설정
+        self.cfg.runner.max_epochs = 30 # 1 only when smoke-test, otherwise 12 or bigger
+        
+        return self.cfg

--- a/mmdetection/trainer.py
+++ b/mmdetection/trainer.py
@@ -20,7 +20,7 @@ def main():
     random_code = str(uuid.uuid4())[:5]
     
     # 설정 생성
-    cfg, model_name, output_dir = create_config('test')
+    cfg, model_name, output_dir = create_config('cascade_rcnn')
     experiment_dir = os.path.join(output_dir, f"{timestamp}_{random_code}")
     os.makedirs(experiment_dir, exist_ok=True)
     cfg.work_dir = experiment_dir
@@ -65,6 +65,6 @@ if __name__ == "__main__":
         }
     }
 
-    sweep_id = wandb.sweep(sweep=sweep_configuration, project='Test Run')
+    sweep_id = wandb.sweep(sweep=sweep_configuration, project='Cascade R-CNN_X-101-64x4d-FPN')
 
     wandb.agent(sweep_id, function=main, count=2)


### PR DESCRIPTION
## Overview
-  Cascade R-CNN 모델 추가

## Change Log
- Cascade R-CNN_X-101-64x4d-FPN 모델 config 추가
- trainer에서 Cascade R-CNN_X-101-64x4d-FPN 모델 config 불러오기
- wandb에 Cascade R-CNN_X-101-64x4d-FPN project 추가

## To Reviewer
1. 내가 돌리고자 하는 모델의 config 파일을 연다. (ex. `/data/ephemeral/home/mmdetection/configs/cascade_rcnn/cascade_rcnn_x101_64x4d_fpn_20e_coco.py`)
2. 첫 줄 `_base_`를 통해 1과 같은 방법으로 해당 모델의 base 모델의 config 파일을 연다. (두 개 이상일 수도 있습니다.)
3. 반복하여 `_base_`폴더를 가리키는 경로들을 모아놓은 리스트만 있는 base 모델의 config 파일을 연다.
4. 3에서 가리키는 경로에 파일들을 열어 model의 구조와 데이터셋 구조를 확인하여 학습시키고자 하는 모델의 config를 수정한다.

## Issue Tags
- Closed | Fixed: #49

