### PR TITLE
🔧 Inference file

### DIFF
--- a/mmdetection/inference.py
+++ b/mmdetection/inference.py
@@ -47,7 +47,7 @@ def inference(cfg, epoch):
     for i, out in enumerate(output):
         prediction_string = ''
         image_info = coco.loadImgs(coco.getImgIds(imgIds=i))[0]
-        image_id = image_info['id']  # 파일 이름 대신 image_id 사용
+        image_id = image_info['id']  # 숫자로 된 image_id를 가져옵니다.
         for j, class_output in enumerate(out):
             for bbox in class_output:
                 score = bbox[4]


### PR DESCRIPTION
## Overview
- COCO 형식에서 이미지 파일 이름이 정확하지 않아서 실제 평가 시점에서 예측 결과를 평가할 이미지와 예측값이 맞지 않아 점수가 0으로 나왔다.
- 현재 image_id 필드에 파일 이름이 들어가고 있는데, 이를 COCO 데이터셋 형식에서 요구하는 형식으로 수정했다.

## Change Log
- 현재 image_id에 파일 이름을 넣고 있는데, image_id는 COCO 데이터셋에서 고유의 ID(숫자)를 사용하게 변경했다.
```python
for i, out in enumerate(output):
    prediction_string = ''
    image_info = coco.loadImgs(coco.getImgIds(imgIds=i))[0]
    image_id = image_info['id']  # 파일 이름 대신 image_id 사용
    for j, class_output in enumerate(out):
        for bbox in class_output:
            score = bbox[4]
            xmin, ymin, xmax, ymax = bbox[0], bbox[1], bbox[2], bbox[3]
            prediction_string += f'{j} {score} {xmin} {ymin} {xmax} {ymax} '
    
    prediction_strings.append(prediction_string.strip())
    file_names.append(image_id)  # image_id를 저장
```

## To Reviewer
- 추가로 readme 파일을 만들어야 합니다!

## Issue Tags
- Closed | Fixed: #60
- See also: #18
