### PR TITLE
♻️ config에서 epoch 받도록 수정

### DIFF
--- a/mmdetection/config/base_config.py
+++ b/mmdetection/config/base_config.py
@@ -8,13 +8,14 @@ import wandb
 from mmdet.utils import get_device
 
 class BaseConfig:
-    def __init__(self):
+    def __init__(self, max_epochs=25):
         self.cfg = None
         self.classes = ("General trash", "Paper", "Paper pack", "Metal", "Glass", 
            "Plastic", "Styrofoam", "Plastic bag", "Battery", "Clothing")
         self.data_dir = '/data/ephemeral/home/dataset/'
         self.output_dir = '/data/ephemeral/home/output/mmdetection/'
         self.num_classes = 10
+        self.max_epochs = max_epochs
 
     def setup_config(self, cfg):
         '''
@@ -42,11 +43,11 @@ class BaseConfig:
         # self.cfg.model.roi_head.bbox_head.num_classes = self.num_classes
         
         # 학습 설정
-        cfg.runner.max_epochs = 1 # 1 only when smoke-test, otherwise 12 or bigger
+        cfg.runner.max_epochs = self.max_epochs # 1 only when smoke-test, otherwise 12 or bigger
         
         # 옵티마이저 설정
         cfg.optimizer_config.grad_clip = dict(max_norm=35, norm_type=2)
-        cfg.checkpoint_config = dict(max_keep_ckpts=1, interval=10)
+        cfg.checkpoint_config = dict(max_keep_ckpts=1, interval=self.max_epochs)        # interval epoch으로 설정
         cfg.device = get_device()
 
         # Wandb 설정
@@ -54,7 +55,7 @@ class BaseConfig:
             dict(type='TextLoggerHook'),
             dict(
                 type='MMDetWandbHook',
-                interval=1,
+                interval=self.max_epochs,           # interval epoch으로 설정
                 log_checkpoint=True,
                 log_checkpoint_metadata=True,
                 num_eval_images=10,

--- a/mmdetection/config/config_factory.py
+++ b/mmdetection/config/config_factory.py
@@ -1,11 +1,11 @@
 # config_factory.py
 import importlib
 
-def create_config(model_name):
+def create_config(model_name, max_epochs=25):
     module_name = f"config.{model_name}_config"
     class_name = f"{model_name}_config"
     module = importlib.import_module(module_name)
     config_class = getattr(module, class_name)
-    config = config_class()
+    config = config_class(max_epochs=max_epochs)
     return config.build_config(), config.model_name, config.output_dir
 

--- a/mmdetection/config/test_config.py
+++ b/mmdetection/config/test_config.py
@@ -11,8 +11,8 @@ from mmdet.datasets import (build_dataloader, build_dataset,
 
 
 class test_config(BaseConfig):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, max_epochs=25):
+        super().__init__(max_epochs=max_epochs) # BaseConfig로 에폭 넘김
         self.config_dir = '/data/ephemeral/home/mmdetection/configs/faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py'
         self.model_name = os.path.basename(self.config_dir).split('.')[0]
         try:
@@ -41,8 +41,5 @@ class test_config(BaseConfig):
         self.cfg.data.test.pipeline[1]['img_scale'] = (512,512) # Resize
 
         self.cfg.model.roi_head.bbox_head.num_classes = 10
-        
-        # 학습 설정
-        self.cfg.runner.max_epochs = 1 # 1 only when smoke-test, otherwise 12 or bigger
         
         return self.cfg

--- a/mmdetection/trainer.py
+++ b/mmdetection/trainer.py
@@ -20,7 +20,8 @@ def main():
     random_code = str(uuid.uuid4())[:5]
     
     # 설정 생성
-    cfg, model_name, output_dir = create_config('swin')
+    max_epochs = 3     # 에폭 설정
+    cfg, model_name, output_dir = create_config('test', max_epochs=max_epochs)  # 모델 Config에 epoch 넘김
 
     experiment_dir = os.path.join(output_dir, f"{timestamp}_{random_code}")
     os.makedirs(experiment_dir, exist_ok=True)


### PR DESCRIPTION
## Overview
- `trainer`에서 max_epochs에 숫자만 수정하여 바로 학습 가능하게 함.

## Change Log
- `trainer`에서 `max_epchs`변수를 통해 epoch 설정
- `create_config` 매소드를 통해 모델 config로 epoch 넘김
- `{model_name}_config`에서 BaseConfig로 epoch 넘김
- `BaseConfig`에서 `runner`에 `max_epochs`를 설정하고, wandb에 epoch만큼 학습이 다 돈 latest 모델만 저장되게 `interval`을 max_epochs로 설정
- 추가로, `{model_name}_config`에서 `#학습 설정`을 BaseConfig에서 다루니 삭제했습니다.

## To Reviewer
- 이전에 추가한 모델을 사용하시거나 새롭게 모델을 추가하실 때, 각 모델 config(`{model_name}_config`)에서 아래 사진 참고하셔서 BaseConfig로 epoch 넘어갈 수 있도록 수정해주세요. `#학습 설정` 부분 한 줄 삭제해주세요.
![image](https://github.com/user-attachments/assets/acc5d91b-e4c2-475e-84f5-35b115c04e80)



## Issue Tags
- Closed | Fixed: #63 
