### PR TITLE
✨ swin backbone 수정, heavy 증강 추가

### DIFF
--- a/mmdetection/config/swin_config.py
+++ b/mmdetection/config/swin_config.py
@@ -17,11 +17,44 @@ class swin_config(BaseConfig):
 
     def build_config(self):
         self.cfg = self.setup_config(self.cfg)
-        # dataset config 수정
-        self.cfg.data.train.classes = self.classes
-        self.cfg.data.train.img_prefix = self.data_dir
-        self.cfg.data.train.ann_file = self.data_dir + 'train2.json' # train json 정보
-        
+        # MultiImageMixDataset으로 데이터셋 변경
+        self.cfg.data.train = dict(
+            type='MultiImageMixDataset',
+            dataset=dict(
+                type='CocoDataset',
+                ann_file=self.data_dir + 'train2.json',
+                img_prefix=self.data_dir,
+                pipeline=[
+                    dict(type='LoadImageFromFile'),
+                    dict(type='LoadAnnotations', with_bbox=True),
+                ],
+                filter_empty_gt=False,
+                classes=self.classes
+            ),
+            pipeline=[
+                # 기존 파이프라인에 Mosaic, RandomAffine, 추가적인 증강 기법을 추가
+                dict(type='Mosaic', img_scale=(1024, 1024), pad_val=114.0),
+                dict(type='RandomAffine', scaling_ratio_range=(0.1, 2), border=(-512 // 2, -512 // 2)), # Affine 변환
+                dict(type='MixUp', img_scale=(1024, 1024), ratio_range=(0.8, 1.2)),                     # MixUp 데이터 증강
+                # dict(type='PhotoMetricDistortion'),                                                   # 색상 왜곡
+                dict(type='Resize', img_scale=[(640, 640), (768, 768)], keep_ratio=True),               # Resize 추가
+                dict(type='RandomCrop', crop_size=(512, 512), allow_negative_crop=True),                # RandomCrop 추가
+                # dict(type='Expand', mean=[123.675, 116.28, 103.53], ratio_range=(1, 4)),              # Expand는 memory가 너무 많이 터져서 삭제
+                dict(type='MinIoURandomCrop', min_ious=(0.1, 0.3, 0.5), min_crop_size=0.3),             # MinIoURandomCrop 추가
+                dict(type='CutOut', n_holes=5, cutout_shape=[(50, 50), (75, 75)]),                      # CutOut 추가
+                dict(type='RandomFlip', flip_ratio=0.5),
+                dict(type='Normalize', **self.cfg.img_norm_cfg),
+                dict(type='Pad', size_divisor=32),
+                dict(type='DefaultFormatBundle'),
+                dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels']),
+            ]
+        )
+
+        # 평가 메트릭에서 'segm' 제거
+        self.cfg.evaluation = dict(
+            interval=1,
+            metric=['bbox'],  # 'segm' 제거하고 bbox만 평가
+        )
         
         self.cfg.data.val.classes = self.classes
         self.cfg.data.val.img_prefix = self.data_dir
@@ -39,7 +72,7 @@ class swin_config(BaseConfig):
         self.cfg.data.samples_per_gpu = 8
         
         self.cfg.model.roi_head.bbox_head['num_classes'] = self.num_classes
-        self.cfg.model.roi_head.mask_head['num_classes'] = self.num_classes
+        # self.cfg.model.roi_head.mask_head['num_classes'] = self.num_classes           # backbone 모델 faster rcnn으로 변경으로 mask_head 삭제
         
         return self.cfg
 


### PR DESCRIPTION
## Overview
- faster rcnn `heavy 증강 + diffusion` 성능이 떨어진 것과 swin-s diffusion 학습 성능이 떨어진 것을 보아, diffusion 이미지가 성능이 나오지 않아 기존 train2로 학습 진행 (최적의 파라미터로 설정)
- `mosaic`와 `mixup` 기법을 사용하기 위해선 `MultiImageMixDataset`으로 데이터셋으로 변경해야 함.
- `MultiImageMixDataset`은 segmentation에 필요한 `gt_mask`와 호환되지 않는 경우가 많음
- `swin_config` 파일에 있는 증강 기법들을 가능한 다 사용하기 위해선 swin 백본 모델을 mask rcnn > `faster rcnn`으로 변경
![image](https://github.com/user-attachments/assets/a1530640-33fc-4cc9-a410-c9eaf32056e4)


## Change Log
- 증강 기법 추가
- 백본 모델 mask rcnn > faster rcnn 으로 변경
- `mask_head` 제거
- 평가 메트릭에서 'segm' 제거하고 `bbox`만 평가

## To Reviewer
- 성능 판단 후, 백본 모델을 다시 mask rcnn으로 되돌리고, 마스크 학습을 필요로 하지 않는 증강 기법들로 학습 예정
```
        pipeline=[
            dict(type='Mosaic', img_scale=(1024, 1024), pad_val=114.0),
            dict(type='RandomAffine', scaling_ratio_range=(0.1, 2), border=(-512 // 2, -512 // 2)),
            dict(type='MixUp', img_scale=(1024, 1024), ratio_range=(0.8, 1.2)),
            dict(type='Resize', img_scale=[(640, 640), (768, 768)], keep_ratio=True),
            dict(type='RandomFlip', flip_ratio=0.5),
            dict(type='Normalize', **self.cfg.img_norm_cfg),
            dict(type='Pad', size_divisor=32),
            dict(type='DefaultFormatBundle'),
            dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels']),  # 마스크 없이 바운딩 박스와 라벨만 수집
        ]
```


## Issue Tags
- Closed | Fixed: #120 
- See also: #57 
